### PR TITLE
Make the CLI client more robust

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,4 @@
+A list of contributors to playerctl, sorted alphabetically on last names.
+Please keep this list sorted when adding yourself.
+
+Jente Hidskes <hjdskes@gmail.com>

--- a/playerctl/playerctl-cli.c
+++ b/playerctl/playerctl-cli.c
@@ -165,7 +165,7 @@ static gboolean position (const gchar *value, PlayerctlPlayer *player, GError **
     char *endptr = NULL;
     offset = strtod(value, &endptr);
 
-    if (endptr) {
+    if (value == endptr) {
       g_set_error(error, playerctl_cli_error_quark (), 1, "Could not parse position as a number: %s\n", value);
       return FALSE;
     }
@@ -202,10 +202,16 @@ static gboolean set_or_get_volume (const gchar *value, PlayerctlPlayer *player, 
   gdouble level;
 
   if (volume) {
+    char *endptr = NULL;
     size_t last = strlen(volume) - 1;
 
     if(volume[last] == '+' || volume[last] == '-') {
-      gdouble adjustment = g_ascii_strtod(volume, NULL);
+      gdouble adjustment = strtod(volume, &endptr);
+
+      if (volume == endptr) {
+        g_set_error(error, playerctl_cli_error_quark (), 1, "Could not parse volume as a number: %s\n", volume);
+        return FALSE;
+      }
 
       if(volume[last] == '-') {
           adjustment *= -1;
@@ -214,7 +220,12 @@ static gboolean set_or_get_volume (const gchar *value, PlayerctlPlayer *player, 
       g_object_get(player, "volume", &level, NULL);
       level += adjustment;
     } else {
-      level = g_ascii_strtod(volume, NULL);
+      level = strtod(volume, &endptr);
+      if (volume == endptr) {
+        g_set_error(error, playerctl_cli_error_quark (), 1, "Could not parse volume as a number: %s\n", volume);
+        return FALSE;
+      }
+
     }
     g_object_set(player, "volume", level, NULL);
   } else {

--- a/playerctl/playerctl-cli.c
+++ b/playerctl/playerctl-cli.c
@@ -288,7 +288,7 @@ struct PlayerCommand {
   { "metadata", &get_metadata },
 };
 
-static gboolean parse_player_command (gchar **command, PlayerctlPlayer *player, GError **error)
+static gboolean handle_player_command (gchar **command, PlayerctlPlayer *player, GError **error)
 {
   for (int i = 0; i < LENGTH(commands); i++) {
     if (g_strcmp0(commands[i].name, command[0]) == 0) {
@@ -374,7 +374,7 @@ int main (int argc, char *argv[])
     goto end;
   }
 
-  if (!parse_player_command(command, player, &error)) {
+  if (!handle_player_command(command, player, &error)) {
     g_printerr("Could not execute command: %s\n", error->message);
     exit_status = 1;
   }

--- a/playerctl/playerctl-cli.c
+++ b/playerctl/playerctl-cli.c
@@ -281,9 +281,7 @@ static gchar *list_player_names(GError **err)
 
   for (int i = 0; i < reply_count; i += 1) {
     if (g_str_has_prefix(names[i], "org.mpris.MediaPlayer2")) {
-      gchar **bus_name_split = g_strsplit(names[i], ".", 4);
-      g_string_append_printf(names_str, "%s\n", bus_name_split[3]);
-      g_strfreev(bus_name_split);
+      g_string_append_printf(names_str, "%s\n", names[i] + 23);
     }
   }
 

--- a/playerctl/playerctl-cli.c
+++ b/playerctl/playerctl-cli.c
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with playerctl If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2014, Tony Crisci
- * Copyright © 2016, Jente Hidskes <hjdskes@gmail.com>
+ * Copyright © 2014 - 2016, Tony Crisci and contributors.
  */
 
 #include "playerctl.h"

--- a/playerctl/playerctl-player.c
+++ b/playerctl/playerctl-player.c
@@ -504,7 +504,6 @@ PlayerctlPlayer *playerctl_player_new(gchar *name, GError **err)
 
   if (tmp_error != NULL) {
     g_propagate_error(err, tmp_error);
-    return NULL;
   }
 
   return player;
@@ -681,7 +680,7 @@ PlayerctlPlayer *playerctl_player_previous(PlayerctlPlayer *self, GError **err)
  *
  * Returns: (transfer full): The artist from the metadata of the current track
  */
-gchar *playerctl_player_print_metadata_prop(PlayerctlPlayer *self, gchar *property, GError **err)
+gchar *playerctl_player_print_metadata_prop(PlayerctlPlayer *self, const gchar *property, GError **err)
 {
   GVariant *prop_variant;
   const gchar **prop_strv;

--- a/playerctl/playerctl-player.h
+++ b/playerctl/playerctl-player.h
@@ -86,7 +86,7 @@ PlayerctlPlayer *playerctl_player_next(PlayerctlPlayer *self, GError **err);
 
 PlayerctlPlayer *playerctl_player_previous(PlayerctlPlayer *self, GError **err);
 
-gchar *playerctl_player_print_metadata_prop(PlayerctlPlayer *self, gchar *property, GError **err);
+gchar *playerctl_player_print_metadata_prop(PlayerctlPlayer *self, const gchar *property, GError **err);
 
 gchar *playerctl_player_get_artist(PlayerctlPlayer *self, GError **err);
 


### PR DESCRIPTION
Hello again,

As promised in my previous PR, here are the changes I made to the CLI client. The intention is to fix some memory leaks, make it slightly more robust and improve its maintainability. By far the biggest change can be found in 7a98a0e9b42225107aebcdcde41cb0e39a894248, which greatly refactors the whole client. In a nutshell, I changed how the remaining command line arguments are handled:

I introduced a new struct, `PlayerCommand`, abstracting the player commands. Per command, there is an instance of this struct containing its name and a function pointer to a function that processes the command. As before, all leftover command line arguments are passed into a string array (`**command`), which is now scanned by `parse_player_command`. The first matching command is executed.

These changes break the previously huge `main` function into smaller functions, one per command. Adding a new command is as simple as adding a new entry to the `PlayerCommand` array with a corresponding function. In my opinion, this greatly improves the maintainability and readability of the code.

I have tested the functionality pretty extensively, and I think everything works as it should.  The user interface is untouched, e.g. all command line arguments and commands have the same name.

There are two improvements I'd like to make still, but I'd like your opinion on the current changes first so I'll probably do those once this PR is discussed.
1. Enable stricter compiler checks, such as `-Wextra`, `-Wformat`, `-Wundef` and the like.
2. Use compiler annotations to mark non-returning functions (`print_version_and_exit`, `list_all_players_and_exit`) and unused variables.
3. `strtod` recognizes `+` and `-` when they prefix the number. Changing the command line syntax to `[+/-][VALUE]` for `volume` and `position` would give us positive and negative numbers for free, allowing us to drop the check for the last character and the multiplication with -1.

Thanks,

Jente
