### PR TITLE
CLI: send command to multiple players

### DIFF
--- a/playerctl/playerctl-cli.c
+++ b/playerctl/playerctl-cli.c
@@ -406,6 +406,7 @@ int main (int argc, char *argv[])
       if (error != NULL) {
         g_printerr("Connection to player failed: %s\n", error->message);
         exit_status = 1;
+        g_object_unref(player);
         continue;
       }
 


### PR DESCRIPTION
Adds feature request #44.
Sends the command signal to all players if `--player=*` option is passed or to all players in a comma separated list `--player=cmus,spotify`.