### PR TITLE
Fix segfault when strtok is called without a --player argument

### DIFF
--- a/playerctl/playerctl-cli.c
+++ b/playerctl/playerctl-cli.c
@@ -388,8 +388,8 @@ int main (int argc, char *argv[])
   }
 
   const gchar *delim = ",\n";
-  gchar *player_name = player_names == NULL ?
-    NULL : strtok(player_names, delim);
+  const gboolean multiple_names = player_names != NULL;
+  gchar *player_name = multiple_names ? strtok(player_names, delim) : NULL;
 
   for (;;) {
     player = playerctl_player_new(player_name, &error);
@@ -409,6 +409,9 @@ loopend:
     g_object_unref(player);
     g_clear_error(&error);
     error = NULL;
+
+    if (!multiple_names)
+      return exit_status;
 
     player_name = strtok(NULL, delim);
     if (!player_name)


### PR DESCRIPTION
Sorry for all the bugs. A segmentation fault occurs when playerctl is called without any music players specified with the --player option. This was due to strtok's first argument being NULL when called for the first time. I am unsure why I only get this on some machines and not others.