### PR TITLE
Meson fixes

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,1 +1,5 @@
-subdir('reference')
+install_man('playerctl.1')
+if get_option('gtk-doc')
+  gtkdoc = find_program('gtkdoc-scan')
+  subdir('reference')
+endif

--- a/doc/reference/meson.build
+++ b/doc/reference/meson.build
@@ -1,7 +1,8 @@
 glib_prefix = dependency('glib-2.0').get_pkgconfig_variable('prefix')
 glib_docpath = join_paths(glib_prefix, 'share', 'gtk-doc', 'html')
 
-configure_file(input : 'version.xml.in',
+configure_file(
+  input : 'version.xml.in',
   output : 'version.xml',
   configuration : version_conf,
 )

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'playerctl',
   'c',
   version: '0.5.0',
-  meson_version: '>=0.42.0'
+  meson_version: '>=0.46.0'
 )
 
 gnome = import('gnome')

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'playerctl',
   'c',
-  version: '0.5.0',
+  version: '0.6.0',
   meson_version: '>=0.46.0'
 )
 

--- a/meson.build
+++ b/meson.build
@@ -35,8 +35,4 @@ gio_dep = dependency('gio-unix-2.0')
 glib_dep = dependency('glib-2.0')
 
 subdir('playerctl')
-
-if get_option('gtk-doc')
-  gtkdoc = find_program('gtkdoc-scan')
-  subdir('doc')
-endif
+subdir('doc')

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,9 @@
-project('playerctl', 'c',
+project(
+  'playerctl',
+  'c',
   version: '0.5.0',
-  meson_version: '>=0.42.0')
+  meson_version: '>=0.42.0'
+)
 
 gnome = import('gnome')
 pkgconfig = import('pkgconfig')
@@ -9,10 +12,23 @@ version_conf = configuration_data()
 
 playerctl_version = meson.project_version()
 version_array = playerctl_version.split('.')
-version_conf.set('PLAYERCTL_VERSION', meson.project_version())
-version_conf.set('PLAYERCTL_MAJOR_VERSION', version_array[0].to_int())
-version_conf.set('PLAYERCTL_MINOR_VERSION', version_array[1].to_int())
-version_conf.set('PLAYERCTL_MICRO_VERSION', version_array[2].to_int())
+
+version_conf.set(
+  'PLAYERCTL_VERSION',
+  meson.project_version(),
+)
+version_conf.set(
+  'PLAYERCTL_MAJOR_VERSION',
+  version_array[0].to_int(),
+)
+version_conf.set(
+  'PLAYERCTL_MINOR_VERSION',
+  version_array[1].to_int(),
+)
+version_conf.set(
+  'PLAYERCTL_MICRO_VERSION',
+  version_array[2].to_int(),
+)
 
 gobject_dep = dependency('gobject-2.0', version: '>=2.38')
 gio_dep = dependency('gio-unix-2.0')

--- a/playerctl/meson.build
+++ b/playerctl/meson.build
@@ -4,7 +4,7 @@ playerctl_version_header = configure_file(
   configuration: version_conf,
 )
 
-# Include playerctl_version_header
+# Include the just generated playerctl_version header
 configuration_inc = include_directories('../',)
 
 playerctl_generated = gnome.gdbus_codegen(
@@ -23,7 +23,7 @@ playerctl_sources = [
   playerctl_generated,
 ]
 
-# Allow including playerctl.h
+# Allow including playerctl.h during compilation
 add_global_arguments(
   '-DPLAYERCTL_COMPILATION',
   language: 'c',
@@ -84,12 +84,13 @@ if get_option('introspection')
   )
 endif
 
-pkgconfig.generate(libraries: playerctl_shared,
-             subdirs: 'playerctl',
-             version: '0.5.0',
-             name: 'Playerctl',
-             filebase: 'playerctl',
-             description: 'A C library for MPRIS players',
-             requires: 'gobject-2.0',
-             requires_private: 'gio-2.0',
+pkgconfig.generate(
+  libraries: playerctl_shared,
+  subdirs: 'playerctl',
+  version: '0.5.0',
+  name: 'Playerctl',
+  filebase: 'playerctl',
+  description: 'A C library for MPRIS players',
+  requires: 'gobject-2.0',
+  requires_private: 'gio-2.0',
 )

--- a/playerctl/meson.build
+++ b/playerctl/meson.build
@@ -5,7 +5,7 @@ playerctl_version_header = configure_file(
 )
 
 # Include the just generated playerctl_version header
-configuration_inc = include_directories('../',)
+configuration_inc = include_directories('..')
 
 playerctl_generated = gnome.gdbus_codegen(
   'playerctl-generated',
@@ -34,26 +34,19 @@ deps = [
   gio_dep,
 ]
 
-playerctl_shared = shared_library(
+playerctl_lib = both_libraries(
   'playerctl-1.0',
   sources: playerctl_sources,
   dependencies: deps,
+  include_directories: configuration_inc,
   version: '0.0.0',
   install: true,
 )
 
 # Required for linking against the shared lib we just built
 playerctl_shared_link = declare_dependency(
-  link_with: playerctl_shared,
+  link_with: playerctl_lib.get_shared_lib(),
   dependencies: deps,
-)
-
-playerctl_static = static_library(
-  'playerctl-1.0',
-  sources: playerctl_sources,
-  dependencies: deps,
-  version: '0.0.0',
-  install: true,
 )
 
 playerctl_executable = executable(
@@ -71,7 +64,7 @@ install_headers(
 
 if get_option('introspection')
   gnome.generate_gir(
-    playerctl_shared,
+    playerctl_lib.get_shared_lib(),
     sources: [
       'playerctl-player.c',
       'playerctl-player.h',
@@ -84,7 +77,7 @@ if get_option('introspection')
 endif
 
 pkgconfig.generate(
-  libraries: playerctl_shared,
+  libraries: playerctl_lib.get_shared_lib(),
   subdirs: 'playerctl',
   version: '0.5.0',
   name: 'Playerctl',

--- a/playerctl/meson.build
+++ b/playerctl/meson.build
@@ -79,9 +79,9 @@ endif
 pkgconfig.generate(
   libraries: playerctl_lib.get_shared_lib(),
   subdirs: 'playerctl',
-  version: '0.5.0',
+  version: meson.project_version(),
   name: 'Playerctl',
-  filebase: 'playerctl',
+  filebase: 'playerctl-1.0',
   description: 'A C library for MPRIS players',
   requires: 'gobject-2.0',
   requires_private: 'gio-2.0',

--- a/playerctl/meson.build
+++ b/playerctl/meson.build
@@ -42,6 +42,12 @@ playerctl_shared = shared_library(
   install: true,
 )
 
+# Required for linking against the shared lib we just built
+playerctl_shared_link = declare_dependency(
+  link_with: playerctl_shared,
+  dependencies: deps,
+)
+
 playerctl_static = static_library(
   'playerctl-1.0',
   sources: playerctl_sources,
@@ -53,16 +59,9 @@ playerctl_static = static_library(
 playerctl_executable = executable(
   'playerctl',
   'playerctl-cli.c',
-  dependencies: deps,
-  link_with: playerctl_shared,
+  dependencies: playerctl_shared_link,
   include_directories: configuration_inc,
   install: true,
-)
-
-# Required for gtk-doc
-playerctl_shared_link = declare_dependency(
-  link_with: playerctl_shared,
-  dependencies: deps,
 )
 
 install_headers(


### PR DESCRIPTION
Hey there,

after porting a few more projects I've noticed a few things I didn't do quite right here. Changes include:

* Style fixes, the indention was really inconsistent.
* Removing unnecessary bits
* Use both_libraries instead of generating the shared and static library one at a time. This both looks nicer and is faster, since meson only compiles the required files once and links them differently instead of compiling everything twice. This however lifts the meson version requirement to 0.46, which has only been released a few days ago (however, I think most distros update meson regularly. Please tell me if that version requirement is okay, otherwise I'll revert this change)
* Set the correct version (please bump this the next time you do a new release :)
* Install manpages, no matter if gtk-doc is enabled
* Set the version of the installed pkg-config file to the project version, this means you only have to change `version: '0.6.0',` in the top meson.build during version bumps