### PR TITLE
Bump playerctl version in manpage

### DIFF
--- a/doc/playerctl.1
+++ b/doc/playerctl.1
@@ -1,4 +1,4 @@
-.TH PLAYERCTL "1" "April 2018" "playerctl 0.5.0" "User Commands"
+.TH PLAYERCTL "1" "April 2018" "playerctl 0.6.0" "User Commands"
 .SH NAME
 \fBplayerctl\fR \- utility to control media players via MPRIS
 .SH SYNOPSIS


### PR DESCRIPTION
Bump version to 0.6.0 to match current release.

Perhaps updating the version in the manpage could be automated? It should be added to the pre-release checklist.