### PR TITLE
Automatically set correct version of manpage

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ Please keep this list sorted when adding yourself.
 Tony Crisci <tony@dubstepdish.com>
 Jente Hidskes <hjdskes@gmail.com>
 Nick Morrott <knowledgejunkie@gmail.com>
+Rasmus Thomsen <cogitri@exherbo.org>

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,4 +1,10 @@
-install_man('playerctl.1')
+man_page = configure_file(
+  input: 'playerctl.1.in',
+  output: 'playerctl.1',
+  configuration: version_conf
+)
+install_man(man_page)
+
 if get_option('gtk-doc')
   gtkdoc = find_program('gtkdoc-scan')
   subdir('reference')

--- a/doc/playerctl.1.in
+++ b/doc/playerctl.1.in
@@ -1,4 +1,4 @@
-.TH PLAYERCTL "1" "April 2018" "playerctl 0.6.0" "User Commands"
+.TH PLAYERCTL "1" "April 2018" "playerctl @PLAYERCTL_VERSION@" "User Commands"
 .SH NAME
 \fBplayerctl\fR \- utility to control media players via MPRIS
 .SH SYNOPSIS


### PR DESCRIPTION
I guess this breaks the build for autotools, but I didn't bother messing with that since we'll drop that soon anyway.