### PR TITLE
Meson error reporting

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,7 +1,7 @@
 man_page = configure_file(
   input: 'playerctl.1.in',
   output: 'playerctl.1',
-  configuration: version_conf
+  configuration: version_conf,
 )
 install_man(man_page)
 

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -6,6 +6,9 @@ man_page = configure_file(
 install_man(man_page)
 
 if get_option('gtk-doc')
-  gtkdoc = find_program('gtkdoc-scan')
+  gtkdoc = find_program('gtkdoc-scan', required: false)
+  if not gtkdoc.found()
+      error('You need to have gtk-doc installed to generate docs. Disable it with `-Dgtk-doc=false` if you don\'t want to build docs')
+  endif
   subdir('reference')
 endif

--- a/playerctl/meson.build
+++ b/playerctl/meson.build
@@ -63,6 +63,14 @@ install_headers(
 )
 
 if get_option('introspection')
+  # The below isn't strictly required, since meson checks for gobject-introspection anyway when
+  # we call gnome.generate_gir. However, doing it this way we have a little nicer error reporting
+  # in case the user enabled instropection but doesn't have gobject-introspection installed.
+  introspection_dep = dependency('gobject-introspection-1.0', required: false)
+  if not introspection_dep.found()
+      error('You need to have gobject-introspection installed to generate Gir data. Disable it with `-Dintrospection=false` if you don\'t want to build it')
+  endif
+
   gnome.generate_gir(
     playerctl_lib.get_shared_lib(),
     sources: [


### PR DESCRIPTION
Doing it this way we have fancy error messages like:
```
playerctl/meson.build:71:6: ERROR:  Problem encountered: You need to have gobject-introspection installed to generate Gir data. Disable it with `-Dintrospection=false` if you don't want to build it
```
Which help inexperienced users to build playerctl, if they don't have gtk-doc or gobject-introspection installed.