### PR TITLE
Added funtion to replace status by FontAwesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,13 @@ playerctl status --format "STATUS: {{ uc(status) }}"
 # prints 'STATUS: PLAYING'
 ```
 
-| Function   | Argument        | Description                                             |
-| ---------- | --------------- | ------------------------------------------------------- |
-| `lc`       | string          | Convert the string to lowercase.                        |
-| `uc`       | string          | Convert the string to uppercase.                        |
-| `duration` | int             | Convert the duration to hh:mm:ss format.                |
-| `emoji`    | status, volume  | Try to convert the variable to an emoji representation. |
+| Function   | Argument        | Description                                              |
+| ---------- | --------------- | -------------------------------------------------------- |
+| `lc`       | string          | Convert the string to lowercase.                         |
+| `uc`       | string          | Convert the string to uppercase.                         |
+| `duration` | int             | Convert the duration to hh:mm:ss format.                 |
+| `emoji`    | status, volume  | Try to convert the variable to an emoji representation.  |
+| `fa`       | status, volume  | Try to convert the variable to an FontAwesome character. |
 
 ### Following changes
 

--- a/doc/playerctl.1.in
+++ b/doc/playerctl.1.in
@@ -100,6 +100,9 @@ When called on a duration such as \fBposition\fR or \fBmpris:length\fR, convert 
 .TP
 \fBemoji\fR
 Convert the property to an emoji representation. This is only supported for \fBvolume\fR and \fBstatus\fR.
+.TP
+\fBfa\fR
+Convert the property to an FontAwesome character. This is only supported for \fBvolume\fR and \fBstatus\fR.
 .SH EXAMPLES
 .TP
 To print the artist, title, and playback status as an emoji:

--- a/playerctl/playerctl-formatter.c
+++ b/playerctl/playerctl-formatter.c
@@ -296,6 +296,36 @@ static gchar *helperfn_emoji(gchar *key, GVariant *value) {
     return pctl_print_gvariant(value);
 }
 
+static gchar *helperfn_fa(gchar *key, GVariant *value) {
+    if (g_strcmp0(key, "status") == 0 &&
+            g_variant_is_of_type(value, G_VARIANT_TYPE_STRING)) {
+        const gchar *status_str = g_variant_get_string(value, NULL);
+        PlayerctlPlaybackStatus status = 0;
+        if (pctl_parse_playback_status(status_str, &status)) {
+            switch (status) {
+            case PLAYERCTL_PLAYBACK_STATUS_PLAYING:
+                return g_strdup("️");
+            case PLAYERCTL_PLAYBACK_STATUS_STOPPED:
+                return g_strdup("️");
+            case PLAYERCTL_PLAYBACK_STATUS_PAUSED:
+                return g_strdup("");
+            }
+        }
+    } else if (g_strcmp0(key, "volume") == 0 &&
+            g_variant_is_of_type(value, G_VARIANT_TYPE_DOUBLE)) {
+        const gdouble volume = g_variant_get_double(value);
+        if (volume < 0.3333) {
+            return g_strdup("");
+        } else if (volume < 0.6666) {
+            return g_strdup("");
+        } else {
+            return g_strdup("");
+        }
+    }
+
+    return pctl_print_gvariant(value);
+}
+
 struct template_helper {
     const gchar *name;
     gchar *(*func)(gchar *key, GVariant *value);
@@ -304,6 +334,7 @@ struct template_helper {
     {"uc", &helperfn_uc},
     {"duration", &helperfn_duration},
     {"emoji", &helperfn_emoji},
+    {"fa", &helperfn_fa},
 };
 
 static gchar *expand_format(GList *tokens, GVariantDict *context, GError **error) {

--- a/playerctl/playerctl-formatter.c
+++ b/playerctl/playerctl-formatter.c
@@ -296,36 +296,6 @@ static gchar *helperfn_emoji(gchar *key, GVariant *value) {
     return pctl_print_gvariant(value);
 }
 
-static gchar *helperfn_fa(gchar *key, GVariant *value) {
-    if (g_strcmp0(key, "status") == 0 &&
-            g_variant_is_of_type(value, G_VARIANT_TYPE_STRING)) {
-        const gchar *status_str = g_variant_get_string(value, NULL);
-        PlayerctlPlaybackStatus status = 0;
-        if (pctl_parse_playback_status(status_str, &status)) {
-            switch (status) {
-            case PLAYERCTL_PLAYBACK_STATUS_PLAYING:
-                return g_strdup("️");
-            case PLAYERCTL_PLAYBACK_STATUS_STOPPED:
-                return g_strdup("️");
-            case PLAYERCTL_PLAYBACK_STATUS_PAUSED:
-                return g_strdup("");
-            }
-        }
-    } else if (g_strcmp0(key, "volume") == 0 &&
-            g_variant_is_of_type(value, G_VARIANT_TYPE_DOUBLE)) {
-        const gdouble volume = g_variant_get_double(value);
-        if (volume < 0.3333) {
-            return g_strdup("");
-        } else if (volume < 0.6666) {
-            return g_strdup("");
-        } else {
-            return g_strdup("");
-        }
-    }
-
-    return pctl_print_gvariant(value);
-}
-
 struct template_helper {
     const gchar *name;
     gchar *(*func)(gchar *key, GVariant *value);
@@ -334,7 +304,6 @@ struct template_helper {
     {"uc", &helperfn_uc},
     {"duration", &helperfn_duration},
     {"emoji", &helperfn_emoji},
-    {"fa", &helperfn_fa},
 };
 
 static gchar *expand_format(GList *tokens, GVariantDict *context, GError **error) {


### PR DESCRIPTION
This PR adds an function to replace the status and volume by FontAwesome characters similar to `emoji`.
This could be benefitial to many users using i3bar or something similar.

I know this is not the prettiest implementation, but I wanted to avoid making things too complicated or eve introduce an con config file.
If you have a better Idea for a general simple replacement I'm happy to help implementig it. 