### PR TITLE
Update manpage date via meson at buildtime

### DIFF
--- a/doc/playerctl.1.in
+++ b/doc/playerctl.1.in
@@ -1,4 +1,4 @@
-.TH PLAYERCTL "1" "April 2018" "playerctl @PLAYERCTL_VERSION@" "User Commands"
+.TH PLAYERCTL "1" "@PLAYERCTL_RELEASE_MONTH@" "playerctl @PLAYERCTL_VERSION@" "User Commands"
 .SH NAME
 \fBplayerctl\fR \- utility to control media players via MPRIS
 .SH SYNOPSIS

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,8 @@ project(
   meson_version: '>=0.46.0'
 )
 
+release_month = 'October 2018'
+
 gnome = import('gnome')
 pkgconfig = import('pkgconfig')
 
@@ -29,6 +31,10 @@ version_conf.set(
 version_conf.set(
   'PLAYERCTL_MICRO_VERSION',
   version_array[2].to_int(),
+)
+version_conf.set(
+  'PLAYERCTL_RELEASE_MONTH',
+  release_month,
 )
 
 gobject_dep = dependency('gobject-2.0', version: '>=2.38')


### PR DESCRIPTION
Similar to a previous manpage update which added support for updating
the manpage's embedded playerctl version at buildtime, this update adds
support for updating playerctl's release month at buildtime.