### PR TITLE
meson: pass -DPLAYERCTL_COMPILATION to gir compiler

### DIFF
--- a/playerctl/meson.build
+++ b/playerctl/meson.build
@@ -95,6 +95,7 @@ if get_option('introspection')
       'playerctl-player.c',
       'playerctl-player.h',
     ],
+    extra_args : [ '-DPLAYERCTL_COMPILATION' ],
     nsversion: playerctl_major_version + '.0',
     namespace: 'Playerctl',
     includes: ['GObject-2.0'],


### PR DESCRIPTION
fixes cross compilation.